### PR TITLE
fix build of qgis_core for QGIS 3.0 with Crystax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,32 @@
 OSGeo4A
 ==========
 
-This provides a set of scripts to build opensource geo tools for android.
+This provides a set of scripts to build opensource geo tools for android. 
 
 This is *Experimental*
 
 Dependencies instructions
------------
+-------------------------
 - you need a JDK v6 or later (OpenJDK is also good)
 - [Apache ant] (http://ant.apache.org/bindownload.cgi) v1.8 or later
-- [Qt5 for android > 5.6]
-(http://download.qt.io/official_releases/qt/5.6/5.6.1-1/qt-opensource-linux-x64-android-5.6.1-1.run)
-- and all the android stuff. the easiest way to get all the android dependencies
-is to install [Android studio] (http://developer.android.com/sdk/index.html)
-During install, download at least one android SDK platform and the NDK.
+- [Qt5 for android >= 5.9] Install ARMv7 arch support
+- Android SDK (https://developer.android.com/studio/index.html#downloads just command line tools, API 15)
+- Android NDK (Crystax NDK 10.3.2)
 
-we suggest installing the ones that we show in the example config file below
-(ANDROIDAPI, ANDROIDNDKVER).
-
-please note that the API 22+ (Android 5.1+, is not yet supported by the NDK r10e)
-
-[Here] (http://doc.qt.io/qt-5/androidgs.html) are more informations on building QT5
-code for android
-
-Alternatively you can manually get the Android SDK at
-http://developer.android.com/sdk/index.html#Other and the Android NDK at
-http://developer.android.com/ndk/downloads/index.html
+[Here] (http://doc.qt.io/qt-5/androidgs.html) are more information on building QT5 code for android
 
 Build instructions
 -----------
 Create a file config.conf in the root folder by copying the config.conf.default
- file and edit it accordingly to your needs 
+file and edit it accordingly to your needs.
+
+The build system is maintained for QGIS 3.x releases. To build QGIS 2.x releases, modify recipes/qgis/recipe.sh
+accordingly. Alternatively you may want to clone qgis/QGIS locally and point the config.conf file to your local 
+repository.
+
 ```sh
-cd OSGeo4A
+cd OSGeo4A 
 cp config.conf.default config.conf
 # nano config.conf
 ./distribute.sh -dqgis -mqgis
 ```
-
-Patch Qt 5.7
-------------
-
-If you compile with Qt 5.7 it needs a minimal manual patch, [see here](https://github.com/opengisch/OSGeo4A/pull/15#issuecomment-249107332)
-
-
-To get more info about the distribute file, call:
-```sh
-./distribute.sh -h
-```
-

--- a/config.conf.default
+++ b/config.conf.default
@@ -1,23 +1,26 @@
 ### Currently suggested versions ####
-export ANDROIDNDKVER=r10e
+export ANDROIDNDKVER=r12b
 export ANDROIDAPI=15 # min 15 max 21
 
 #### PATHS ####
 export ANDROIDSDK="/path/to/android-sdk"
-# if installed with android studio, this is in ndk-bundle if not
-# download it and install it from 
-# http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin
-export ANDROIDNDK="/path/to/android-sdk/ndk-bundle"
+export ANDROIDNDK="/path/to/crystax-ndk"
 export QTSDK="/path/to/qt/sdk/Qt/5.5"
+
+# For example:
+# export ANDROIDSDK="/opt/android/sdk"
+# export ANDROIDNDK="/opt/android/crystax-ndk-10.3.2"
+# export QTSDK="/opt/Qt/5.9.2"
 
 ### LOCAL SOURCES ###
 # To use local sourcecode instead of the configured URL:
 # export O4A_[module]_DIR=/usr/src/mymodulesource like this
-# export O4A_qfield_DIR="/home/marco/dev/QGIS/QField"
-# export O4A_qgis_DIR="/home/marco/dev/QGIS/master"
+# export O4A_qgis_DIR="/path/to/repository/qgis/QGIS"
 
 ### BUILD ###
 export ARCHES=("armeabi-v7a" "x86")
+#export ARCHES=("armeabi-v7a")
+
 # By default all cores will be used to build
 # Use this option to override
 # export CORES=4

--- a/distribute.sh
+++ b/distribute.sh
@@ -181,7 +181,7 @@ function push_arm() {
   #export OFLAG="-Os"
   #export OFLAG="-O2"
 
-  export CFLAGS="-DANDROID -mandroid $OFLAG -fomit-frame-pointer --sysroot $NDKPLATFORM -I$STAGE_PATH/include"
+  export CFLAGS="-DANDROID -mandroid $OFLAG -fomit-frame-pointer --sysroot $NDKPLATFORM -I$STAGE_PATH/include -L$ANDROIDNDK/sources/crystax/libs/$ARCH"
   if [ "X$ARCH" == "Xarmeabi-v7a" ]; then
     CFLAGS+=" -march=armv7-a -mfloat-abi=softfp -mfpu=vfp -mthumb"
   fi
@@ -225,7 +225,7 @@ function push_arm() {
                            -isystem $ANDROIDNDK/sources/cxx-stl/gnu-libstdc++/$TOOLCHAIN_VERSION/libs/${ARCH}/include \
                            -isystem $ANDROIDNDK/platforms/android-$ANDROIDAPI/arch-$SHORTARCH/usr/include"
 
-  export LDFLAGS="-lm -L$STAGE_PATH/lib -L$ANDROIDNDK/sources/crystax/libs/$ARCH/"
+  export LDFLAGS="-lm -L$STAGE_PATH/lib -L$ANDROIDNDK/sources/crystax/libs/$ARCH"
 
   export PATH="$STAGE_PATH/bin:$ANDROIDNDK/toolchains/$TOOLCHAIN_BASEDIR-$TOOLCHAIN_VERSION/prebuilt/$PYPLATFORM-x86/bin/:$ANDROIDNDK/toolchains/$TOOLCHAIN_BASEDIR-$TOOLCHAIN_VERSION/prebuilt/$PYPLATFORM-x86_64/bin/:$ANDROIDNDK:$ANDROIDSDK/tools:$QTSDK/android_$QT_ARCH_PREFIX/bin:$PATH"
 

--- a/layouts/qgis-debug/res/values/libs.xml
+++ b/layouts/qgis-debug/res/values/libs.xml
@@ -33,14 +33,14 @@
       <item>gdal</item>
       <item>proj</item>
       <item>spatialindex</item>
-      <item>qscintilla2</item>
-      <item>qwt</item>
-      <item>qwtpolar</item>
+      <!-- <item>qscintilla2</item> -->
+      <!-- <item>qwt</item> -->
+      <!-- <item>qwtpolar</item> -->
       <item>pq</item>
       <item>spatialite</item>
 
       <item>qgis_core</item>
-      <item>qgis_gui</item>
+      <!-- <item>qgis_gui</item> -->
       <item>qgis_analysis</item>
       <item>qgis_networkanalysis</item>
     </array>

--- a/layouts/qgismobile-debug/res/values/libs.xml
+++ b/layouts/qgismobile-debug/res/values/libs.xml
@@ -34,14 +34,14 @@
       <item>gdal</item>
       <item>proj</item>
       <item>spatialindex</item>
-      <item>qscintilla2</item>
-      <item>qwt</item>
-      <item>qwtpolar</item>
+      <!-- <item>qscintilla2</item> -->
+      <!-- <item>qwt</item> -->
+      <!-- <item>qwtpolar</item> -->
       <item>pq</item>
       <item>spatialite</item>
 
       <item>qgis_core</item>
-      <item>qgis_gui</item>
+      <!--  <item>qgis_gui</item> -->
       <item>qgis_analysis</item>
       <item>qgis_networkanalysis</item>
 

--- a/recipes/gdal/recipe.sh
+++ b/recipes/gdal/recipe.sh
@@ -4,7 +4,7 @@
 VERSION_gdal=2.2.1
 
 # dependencies of this recipe
-DEPS_gdal=(iconv sqlite3 geos libtiff postgresql)
+DEPS_gdal=(iconv sqlite3 geos libtiff postgresql expat)
 
 # url of the package
 URL_gdal=http://download.osgeo.org/gdal/$VERSION_gdal/gdal-${VERSION_gdal}.tar.gz
@@ -47,7 +47,8 @@ function shouldbuild_gdal() {
 function build_gdal() {
   try rsync -a $BUILD_gdal/ $BUILD_PATH/gdal/build-$ARCH/
   try cd $BUILD_PATH/gdal/build-$ARCH
-	push_arm
+
+  push_arm
   LIBS="-lgnustl_shared -lsupc++ -lstdc++" \
   LDFLAGS="${LDFLAGS} -L$ANDROIDNDK/sources/cxx-stl/gnu-libstdc++/$TOOLCHAIN_VERSION/libs/${ARCH}" \
     try ${BUILD_PATH}/gdal/build-$ARCH/configure \
@@ -55,10 +56,11 @@ function build_gdal() {
     --host=${TOOLCHAIN_PREFIX} \
     --with-sqlite3=$STAGE_PATH \
     --with-geos=$STAGE_PATH/bin/geos-config \
-    --with-pg=no
+    --with-pg=no \
+    --with-expat=$STAGE_PATH
   try make
   try make install &> install.log
-	pop_arm
+  pop_arm
 }
 
 # function called after all the compile have been done

--- a/recipes/libspatialite/recipe.sh
+++ b/recipes/libspatialite/recipe.sh
@@ -56,7 +56,7 @@ function build_libspatialite() {
     --target=android \
     --with-geosconfig=$STAGE_PATH/bin/geos-config \
     --enable-libxml2=no
-  try make &> make.log
+  try make
   try make install &> install.log
 	pop_arm
 }

--- a/recipes/libzip/recipe.sh
+++ b/recipes/libzip/recipe.sh
@@ -50,6 +50,7 @@ function build_libzip() {
   pop_arm
   cp $BUILD_PATH/libzip/master/libs/${ARCH}/*.so ${STAGE_PATH}/lib
   cp $BUILD_PATH/libzip/master/jni/*.h ${STAGE_PATH}/include
+  rm -f ${STAGE_PATH}/include/config.h
 }
 
 # function called after all the compile have been done

--- a/recipes/qca/recipe.sh
+++ b/recipes/qca/recipe.sh
@@ -7,11 +7,12 @@ VERSION_qca=2.1.0
 DEPS_qca=()
 
 # url of the package
-URL_qca=http://delta.affinix.com/download/qca/2.0/qca-${VERSION_qca}.tar.gz
-#URL_qca=http://quickgit.kde.org/?p=qca.git&a=snapshot&h=4f966b0217c10b6fd3c12caf7d2467759fbec7f7&fmt=tgz
+# URL_qca=http://delta.affinix.com/download/qca/2.0/qca-${VERSION_qca}.tar.gz
+# URL_qca=http://quickgit.kde.org/?p=qca.git&a=snapshot&h=4f966b0217c10b6fd3c12caf7d2467759fbec7f7&fmt=tgz
+URL_qca=https://github.com/KDE/qca/archive/v${VERSION_qca}.tar.gz
 
 # md5 of the package
-MD5_qca=c2b00c732036244701bae4853a2101cf
+MD5_qca=b1b8ffad920c4cb3c286bcf34a83f76b
 
 # default build path
 BUILD_qca=$BUILD_PATH/qca/$(get_directory $URL_qca)

--- a/recipes/qgis/recipe.sh
+++ b/recipes/qgis/recipe.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 # version of your package
-VERSION_qgis=2.14.11
+VERSION_qgis=3.0.0
 
 # dependencies of this recipe
-DEPS_qgis=(gdal qwt qca qscintilla libspatialite spatialindex expat gsl postgresql libzip qtkeychain)
+DEPS_qgis=(gdal qca libspatialite spatialindex expat gsl postgresql libzip qtkeychain)
 # DEPS_qgis=()
 
 # url of the package
-URL_qgis=https://github.com/qgis/QGIS/archive/final-2_14_11.tar.gz
+URL_qgis=https://github.com/qgis/QGIS/archive/c176a8bfb0f7f25edea15069318f769e7c9c82bf.tar.gz # QGIS 3.0 pre-release
 
 # md5 of the package
 MD5_qgis=3a00ec4a051d99b8cc0e5306630d3685
@@ -29,7 +29,9 @@ function prebuild_qgis() {
 function build_qgis() {
   try mkdir -p $BUILD_PATH/qgis/build-$ARCH
   try cd $BUILD_PATH/qgis/build-$ARCH
-	push_arm
+
+  push_arm
+
   try cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_TOOLCHAIN_FILE=$ROOT_PATH/tools/android.toolchain.cmake \
@@ -37,7 +39,6 @@ function build_qgis() {
     -DWITH_DESKTOP=ON \
     -DDISABLE_DEPRECATED=ON \
     -DWITH_QTWEBKIT=OFF \
-    -DPYTHON_EXECUTABLE=`which python` \
     -DQT_LRELEASE_EXECUTABLE=`which lrelease` \
     -DFLEX_EXECUTABLE=`which flex` \
     -DBISON_EXECUTABLE=`which bison` \
@@ -70,18 +71,12 @@ function build_qgis() {
     -DWITH_QTMOBILITY=OFF \
     -DCMAKE_INSTALL_PREFIX:PATH=$STAGE_PATH \
     -DENABLE_QT5=ON \
-    -DPYTHON_VER=2.7 \
     -DENABLE_TESTS=OFF \
     -DEXPAT_INCLUDE_DIR=$STAGE_PATH/include \
     -DEXPAT_LIBRARY=$STAGE_PATH/lib/libexpat.so \
-    -DQWT_INCLUDE_DIR=$STAGE_PATH/include \
-    -DQWT_LIBRARY=$STAGE_PATH/lib/libqwt.so \
     -DWITH_INTERNAL_QWTPOLAR=OFF \
     -DWITH_QWTPOLAR=OFF \
-    -DQWTPOLAR_INCLUDE_DIR=$STAGE_PATH/include \
-    -DQWTPOLAR_LIBRARY=$STAGE_PATH/lib/libqwtpolar.so \
-    -DQSCINTILLA_INCLUDE_DIR=$STAGE_PATH/include \
-    -DQSCINTILLA_LIBRARY=$STAGE_PATH/lib/libqscintilla2.so \
+    -DWITH_GUI=OFF \
     -DSPATIALINDEX_LIBRARY=$STAGE_PATH/lib/libspatialindex.so \
     -DWITH_APIDOC=OFF \
     -DWITH_ASTYLE=OFF \
@@ -90,6 +85,7 @@ function build_qgis() {
     -DANDROID_ABI=$ARCH \
     -DANDROID_NATIVE_API_LEVEL=$ANDROIDAPI \
     $BUILD_qgis
+
   try $MAKESMP install
   pop_arm
 }


### PR DESCRIPTION
* Fixed README to point to Crystax NDK and QGIS 3.0
* Fixed distribute.sh CFLAGS to fix "GIntBig linkage problems" in GDAL build. The bug was caused by configure checks, because configure tried to compile simple C programs, but was missing -lcrystax library. So it incorrectly marked all checks as failed.
* Fixed some recipes for failing builds.
* Used WITH_GUI=FALSE for qgis build. This removes dependency on qscintilla and qwt.
