### PR TITLE
Update QGIS

### DIFF
--- a/recipes/qgis/recipe.sh
+++ b/recipes/qgis/recipe.sh
@@ -8,10 +8,10 @@ DEPS_qgis=(zlib gdal qca libspatialite libspatialindex expat gsl postgresql libz
 # DEPS_qgis=()
 
 # url of the package
-URL_qgis=https://github.com/qgis/QGIS/archive/4fe3d2f4e6032e502b10725ad3cd78c18f6a739c.tar.gz
+URL_qgis=https://github.com/qgis/QGIS/archive/060750420220ae304ce37a7d1015d0c89a567294.tar.gz
 
 # md5 of the package
-MD5_qgis=470a24620cfc9df3f1883cf4e9ec53e2
+MD5_qgis=cc9e44ed412bafb189bea1e2698666c5
 
 # default build path
 BUILD_qgis=$BUILD_PATH/qgis/$(get_directory $URL_qgis)


### PR DESCRIPTION
This brings it a couple of important fixes for QField:
- https://github.com/qgis/QGIS/pull/39336 : a SVG marker fix needed by @3nids and @lucienicolier 
- https://github.com/qgis/QGIS/pull/39341 : a fix to improve QField's legend images
- an array of fixes and improvements to vector tile support (including the addition of a @vector_tile_zoom which, without it, breaks rendering of vector tiles on QField ATM)
- ~3 weeks of bug fixing by the whole QGIS dev team :)