### PR TITLE
Update QGIS to latest 3.18 branch commit

### DIFF
--- a/recipes/qgis/recipe.sh
+++ b/recipes/qgis/recipe.sh
@@ -8,10 +8,10 @@ DEPS_qgis=(gdal qca libspatialite libspatialindex expat gsl postgresql libzip qt
 # DEPS_qgis=()
 
 # url of the package
-URL_qgis=https://github.com/qgis/QGIS/archive/a09ffc86ce03d0870da4883e0e111c55c1ac2529.tar.gz
+URL_qgis=https://github.com/qgis/QGIS/archive/24368627ea2f8365bef5ed9c7d019594fc78cb9c.tar.gz
 
 # md5 of the package
-MD5_qgis=c338d81d09f0b77bcceb01c5a2d0c167
+MD5_qgis=b15181f6827ee7987ca5c271f24ea656
 
 # default build path
 BUILD_qgis=$BUILD_PATH/qgis/$(get_directory $URL_qgis)


### PR DESCRIPTION
Updating QGIS to latest 3.18 branch commit to prepare for upcoming 1.9 release. A large amount of crucial fixes included in there.