### PR TITLE
Update GEOS lib to 3.9.1

### DIFF
--- a/recipes/geos/recipe.sh
+++ b/recipes/geos/recipe.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of your package
-VERSION_geos=3.8.1
+VERSION_geos=3.9.1
 
 # dependencies of this recipe
 DEPS_geos=()
@@ -10,7 +10,7 @@ DEPS_geos=()
 URL_geos=https://github.com/libgeos/geos/archive/${VERSION_geos}.tar.gz
 
 # md5 of the package
-MD5_geos=22d1bc7d276fecc7e1b5f55c47632d6a
+MD5_geos=ea4ced8ff19533e8b527b7316d7010bb
 
 # default build path
 BUILD_geos=$BUILD_PATH/geos/$(get_directory $URL_geos)

--- a/recipes/openssl/recipe.sh
+++ b/recipes/openssl/recipe.sh
@@ -2,7 +2,7 @@
 
 
 # version of your package
-VERSION_openssl=1.1.1g
+VERSION_openssl=1.1.1j
 
 # dependencies of this recipe
 DEPS_openssl=()
@@ -11,7 +11,7 @@ DEPS_openssl=()
 URL_openssl=https://www.openssl.org/source/openssl-${VERSION_openssl}.tar.gz
 
 # md5 of the package
-MD5_openssl=76766e98997660138cdaf13a187bd234
+MD5_openssl=cccaa064ed860a2b4d1303811bf5c682
 
 # default recipe path
 RECIPE_openssl=$RECIPES_PATH/openssl


### PR DESCRIPTION
Latest GEOS lib speeds up rendering of polygon labels (and I assume other scenarios), giving QField a better overall rendering time.