### PR TITLE
Update PROJ to 8.0.1

### DIFF
--- a/.docker/qt-ndk/Dockerfile
+++ b/.docker/qt-ndk/Dockerfile
@@ -45,6 +45,10 @@ RUN dpkg --add-architecture i386 && apt-get -qq update && apt-get -qq dist-upgra
     sudo \
     curl \
     make \
+    autoconf \
+    automake \
+    autotools-dev \
+    libtool \
     openjdk-8-jdk \
     ant \
     libarchive-tools \

--- a/recipes/librttopo/recipe.sh
+++ b/recipes/librttopo/recipe.sh
@@ -4,7 +4,7 @@
 VERSION_librttopo=1.1.0
 
 # dependencies of this recipe
-DEPS_librttopo=()
+DEPS_librttopo=(geos)
 
 # url of the package
 URL_librttopo=https://git.osgeo.org/gitea/rttopo/librttopo/archive/librttopo-${VERSION_librttopo}.tar.gz
@@ -52,6 +52,7 @@ function build_librttopo() {
     --host=$TOOLCHAIN_PREFIX \
     --build=x86_64 \
     --prefix=$STAGE_PATH \
+    --with-geosconfig=$STAGE_PATH/bin/geos-config
   try $MAKESMP
   try $MAKESMP install
 

--- a/recipes/librttopo/recipe.sh
+++ b/recipes/librttopo/recipe.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# version of your package
+VERSION_librttopo=1.1.0
+
+# dependencies of this recipe
+DEPS_librttopo=()
+
+# url of the package
+URL_librttopo=https://git.osgeo.org/gitea/rttopo/librttopo/archive/librttopo-${VERSION_librttopo}.tar.gz
+
+# md5 of the package
+MD5_librttopo=0952b78943047ca69a9e6cbef6146869
+
+# default build path
+BUILD_librttopo=$BUILD_PATH/librttopo/$(get_directory $URL_librttopo)
+
+# default recipe path
+RECIPE_librttopo=$RECIPES_PATH/librttopo
+
+# function called for preparing source code if needed
+# (you can apply patch etc here.)
+function prebuild_librttopo() {
+  cd $BUILD_librttopo
+
+  # check marker
+  if [ -f .patched ]; then
+    return
+  fi
+
+  ./autogen.sh
+
+  touch .patched
+}
+
+function shouldbuild_librttopo() {
+  # If lib is newer than the sourcecode skip build
+  if [ $BUILD_PATH/librttopo/build-$ARCH/lib/librttopo.so -nt $BUILD_librttopo/.patched ]; then
+    DO_BUILD=0
+  fi
+}
+
+# function called to build the source code
+function build_librttopo() {
+  try mkdir -p $BUILD_PATH/librttopo/build-$ARCH
+  try cd $BUILD_PATH/librttopo/build-$ARCH
+
+  push_arm
+  
+  #try $BUILD_librttopo/autogen.sh
+  try $BUILD_librttopo/configure \
+    --host=$TOOLCHAIN_PREFIX \
+    --build=x86_64 \
+    --prefix=$STAGE_PATH \
+  try $MAKESMP
+  try $MAKESMP install
+
+  pop_arm
+}
+
+# function called after all the compile have been done
+function postbuild_librttopo() {
+	true
+}

--- a/recipes/libspatialite/patches/spatialite.patch
+++ b/recipes/libspatialite/patches/spatialite.patch
@@ -1,6 +1,6 @@
 --- a/configure
 +++ b/configure
-@@ -11971,8 +11971,17 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu)
+@@ -12535,8 +12535,17 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu)
    version_type=linux
    need_lib_prefix=no
    need_version=no
@@ -20,7 +20,7 @@
    finish_cmds='PATH="\$PATH:/sbin" ldconfig -n $libdir'
    shlibpath_var=LD_LIBRARY_PATH
    shlibpath_overrides_runpath=no
-@@ -15808,8 +15817,17 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu)
+@@ -16372,8 +16381,17 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu)
    version_type=linux
    need_lib_prefix=no
    need_version=no

--- a/recipes/libspatialite/recipe.sh
+++ b/recipes/libspatialite/recipe.sh
@@ -4,7 +4,7 @@
 VERSION_libspatialite=5.0.1
 
 # dependencies of this recipe
-DEPS_libspatialite=(sqlite3 proj iconv freexl geos)
+DEPS_libspatialite=(sqlite3 proj iconv freexl geos librttopo)
 
 # url of the package
 URL_libspatialite=http://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-${VERSION_libspatialite}.tar.gz
@@ -61,7 +61,7 @@ function build_libspatialite() {
     --enable-static=no \
     --with-geosconfig=$STAGE_PATH/bin/geos-config \
     --enable-libxml2=no \
-    --enable-rttopo=no \
+    --enable-rttopo=yes \
     --enable-gcp=no \
     --enable-minizip=no \
     --disable-dependency-tracking

--- a/recipes/libspatialite/recipe.sh
+++ b/recipes/libspatialite/recipe.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of your package
-VERSION_libspatialite=4.3.0a
+VERSION_libspatialite=5.0.1
 
 # dependencies of this recipe
 DEPS_libspatialite=(sqlite3 proj iconv freexl geos)
@@ -10,7 +10,7 @@ DEPS_libspatialite=(sqlite3 proj iconv freexl geos)
 URL_libspatialite=http://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-${VERSION_libspatialite}.tar.gz
 
 # md5 of the package
-MD5_libspatialite=6b380b332c00da6f76f432b10a1a338c
+MD5_libspatialite=5f4a961afbb95dcdc715b5d7f8590573
 
 # default build path
 BUILD_libspatialite=$BUILD_PATH/libspatialite/$(get_directory $URL_libspatialite)
@@ -44,22 +44,31 @@ function shouldbuild_libspatialite() {
 
 # function called to build the source code
 function build_libspatialite() {
-  try mkdir -p $BUILD_PATH/libspatialite/build-$ARCH
+  try rsync -a $BUILD_libspatialite/ $BUILD_PATH/libspatialite/build-$ARCH/
   try cd $BUILD_PATH/libspatialite/build-$ARCH
+  
   push_arm
+  
   export CPPFLAGS=$CXXFLAGS
   LDFLAGS="$LDFLAGS -llog" \
-  CFLAGS="-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H" \
-    try $BUILD_libspatialite/configure \
+    try $BUILD_PATH/libspatialite/build-$ARCH/configure \
     --prefix=$STAGE_PATH \
     --host=$TOOLCHAIN_PREFIX \
     --build=x86_64 \
     --target=android \
+    --enable-examples=no \
+    --enable-proj=yes \
+    --enable-static=no \
     --with-geosconfig=$STAGE_PATH/bin/geos-config \
-    --enable-libxml2=no
-
+    --enable-libxml2=no \
+    --enable-rttopo=no \
+    --enable-gcp=no \
+    --enable-minizip=no \
+    --disable-dependency-tracking
+  
   try $MAKESMP
   try make install &> install.log
+  
   pop_arm
 }
 

--- a/recipes/libspatialite/recipe.sh
+++ b/recipes/libspatialite/recipe.sh
@@ -4,7 +4,7 @@
 VERSION_libspatialite=5.0.1
 
 # dependencies of this recipe
-DEPS_libspatialite=(sqlite3 proj iconv freexl geos librttopo)
+DEPS_libspatialite=(sqlite3 proj iconv freexl geos)
 
 # url of the package
 URL_libspatialite=http://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-${VERSION_libspatialite}.tar.gz
@@ -61,7 +61,7 @@ function build_libspatialite() {
     --enable-static=no \
     --with-geosconfig=$STAGE_PATH/bin/geos-config \
     --enable-libxml2=no \
-    --enable-rttopo=yes \
+    --enable-rttopo=no \
     --enable-gcp=no \
     --enable-minizip=no \
     --disable-dependency-tracking

--- a/recipes/libtiff/recipe.sh
+++ b/recipes/libtiff/recipe.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of your package
-VERSION_libtiff=4.0.9
+VERSION_libtiff=4.2.0
 
 # dependencies of this recipe
 DEPS_libtiff=()
@@ -10,7 +10,7 @@ DEPS_libtiff=()
 URL_libtiff=http://download.osgeo.org/libtiff/tiff-${VERSION_libtiff}.tar.gz
 
 # md5 of the package
-MD5_libtiff=54bad211279cc93eb4fca31ba9bfdc79
+MD5_libtiff=2bbf6db1ddc4a59c89d6986b368fc063
 
 # default build path
 BUILD_libtiff=$BUILD_PATH/libtiff/$(get_directory $URL_libtiff)

--- a/recipes/proj/recipe.sh
+++ b/recipes/proj/recipe.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of your package
-VERSION_proj=7.2.1
+VERSION_proj=8.0.1
 
 # dependencies of this recipe
 DEPS_proj=(sqlite3 libtiff)
@@ -10,7 +10,7 @@ DEPS_proj=(sqlite3 libtiff)
 URL_proj=https://download.osgeo.org/proj/proj-${VERSION_proj}.tar.gz
 
 # md5 of the package
-MD5_proj=befbafd25e65ddf0c26a8321d8bcdcd2
+MD5_proj=c2511f070f0e4854b1b8bf8baccf294c
 
 # default build path
 BUILD_proj=$BUILD_PATH/proj/$(get_directory $URL_proj)
@@ -50,6 +50,8 @@ function build_proj() {
     -DCMAKE_INSTALL_PREFIX:PATH=$STAGE_PATH \
     -DPROJ_TESTS=OFF \
     -DEXE_SQLITE3=$(which sqlite3) \
+    -DENABLE_CURL=OFF \
+    -DBUILD_PROJSYNC=OFF \
     $BUILD_proj
   try $MAKESMP install
   pop_arm

--- a/recipes/proj/recipe.sh
+++ b/recipes/proj/recipe.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of your package
-VERSION_proj=6.3.2
+VERSION_proj=7.2.1
 
 # dependencies of this recipe
 DEPS_proj=(sqlite3)
@@ -10,7 +10,7 @@ DEPS_proj=(sqlite3)
 URL_proj=https://download.osgeo.org/proj/proj-${VERSION_proj}.tar.gz
 
 # md5 of the package
-MD5_proj=2ca6366e12cd9d34d73b4602049ee480
+MD5_proj=befbafd25e65ddf0c26a8321d8bcdcd2
 
 # default build path
 BUILD_proj=$BUILD_PATH/proj/$(get_directory $URL_proj)

--- a/recipes/proj/recipe.sh
+++ b/recipes/proj/recipe.sh
@@ -4,7 +4,7 @@
 VERSION_proj=7.2.1
 
 # dependencies of this recipe
-DEPS_proj=(sqlite3)
+DEPS_proj=(sqlite3 libtiff)
 
 # url of the package
 URL_proj=https://download.osgeo.org/proj/proj-${VERSION_proj}.tar.gz


### PR DESCRIPTION
It's been out there for a while now (7.1 in ubuntu since 20.10, 7.2 in osgeo4win, etc.). Beyond catching the series of projection updates and bug fixes, it unlocks some epoch functionality that will make QField even more accurate.