### PR TITLE
Downgrade sqlite3 to 3.35.5 to fix spatialite regression

### DIFF
--- a/recipes/sqlite3/recipe.sh
+++ b/recipes/sqlite3/recipe.sh
@@ -10,7 +10,7 @@ DEPS_sqlite3=()
 URL_sqlite3=http://www.sqlite.org/2021/sqlite-amalgamation-${VERSION_sqlite3}.zip
 
 # md5 of the package
-MD5_sqlite3=c5d360c74111bafae1b704721ff18fe6
+MD5_sqlite3=5526d3309d889d0b9ed8ce73c1ee3b23
 
 # default build path
 BUILD_sqlite3=$BUILD_PATH/sqlite3/$(get_directory $URL_sqlite3)

--- a/recipes/sqlite3/recipe.sh
+++ b/recipes/sqlite3/recipe.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of your package
-VERSION_sqlite3=3360000
+VERSION_sqlite3=3350500
 
 # dependencies of this recipe
 DEPS_sqlite3=()


### PR DESCRIPTION
Alright, for QField 1.10, we have two choices: upgrade GDAL from 3.3.2 to 3.4.0, or downgrade sqlite3 from 3.36.0 to 3.35.5 -- I guess the latter is safer, so going ahead with that.

Long story short, sqlite has change the way it handles views and ROWID, which caused a regression in GDAL (a fix was pushed into 3.4.0 https://github.com/OSGeo/gdal/pull/4017).